### PR TITLE
Aumento de cobertura de casos dc2d

### DIFF
--- a/src/main/java/org/acme/DeploymentResource.java
+++ b/src/main/java/org/acme/DeploymentResource.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.DumperOptions;
 
 import java.util.Map;
 
@@ -17,7 +18,14 @@ public class DeploymentResource {
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)  // Now returning plain text
     public Response createDeploymentConfig(String dcYaml) throws Exception {
-        Yaml yaml = new Yaml();
+
+        // Set dummper options
+        DumperOptions options = new DumperOptions();
+        options.setIndent(2);
+        options.setPrettyFlow(true);
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+ 
+        Yaml yaml = new Yaml(options);
         Map<String, Object> dcMap = yaml.load(dcYaml);
 
         // 1. Change apiVersion

--- a/src/main/java/org/acme/DeploymentResource.java
+++ b/src/main/java/org/acme/DeploymentResource.java
@@ -137,9 +137,13 @@ public class DeploymentResource {
             // 7. Remove spec.triggers
             spec.remove("triggers");
 
+            // 8. Remove spec.test
+            spec.remove("test");
 
-            // 8. Remove status block if it exists
+
+            // 9. Remove status block if it exists
             dcMap.remove("status");
+            
         }
 
         // Convert back to YAML

--- a/src/main/java/org/acme/DeploymentResource.java
+++ b/src/main/java/org/acme/DeploymentResource.java
@@ -54,13 +54,19 @@ public class DeploymentResource {
         Map<String, Object> spec = (Map<String, Object>) dcMap.get("spec");
         if (spec != null) {
 
+            // Store selector values because select will be cleared
+            Map<String, Object> selectorBackup = (Map<String, Object>) spec.get("selector");
+
             Map<String, Object> selector = (Map<String, Object>) spec.get("selector");
             if (selector == null) {
                 selector = new java.util.HashMap<>();
                 spec.put("selector", selector);
+            } else {
+                // Remove old labels from selector
+                selector.clear();
             }
 
-            Map<String, Object> matchLabels = (Map<String, Object>) selector.get("matchLabels");
+            Map<String, Object> matchLabels = (Map<String, Object>) selectorBackup.get("matchLabels");
             if (matchLabels == null) {
                 matchLabels = new java.util.HashMap<>();
                 selector.put("matchLabels", matchLabels);


### PR DESCRIPTION
Se agregan las siguientes mejoras:

- Agrega "dumper options" para que la salida sea  YAML de más fácil lectura
- Agrega "strategy" tipo RollingUpdate al deployment
- Remueve spec.test si existe del DC
- Corrige "selector" eliminando duplicidad